### PR TITLE
feat: add template() CEL function for prompt string templating

### DIFF
--- a/docs/declarative-agents.md
+++ b/docs/declarative-agents.md
@@ -559,6 +559,25 @@ Aligned with the [cel-go strings extension](https://pkg.go.dev/github.com/google
 'json(state.data.trim())["name"].lowerAscii()'
 ```
 
+#### Templating
+
+| Function | Description | Example |
+| --- | --- | --- |
+| `template(string, map)` | Substitute `${key}` placeholders from a map | `template("Hello ${name}!", {"name": "world"})` |
+
+Unresolved placeholders (keys not in the map) are left as-is. Non-string values are coerced to strings.
+
+```yaml
+# Inject state into a prompt template
+'template(prompts["plan-prompt"]["instructions"], {"skill_instructions": state.skill_instructions})'
+
+# Multiple placeholders
+'template("Hello ${name}, your role is ${role}.", {"name": state.user, "role": state.assigned_role})'
+
+# Non-string values are coerced
+'template("Count: ${n}, Active: ${flag}", {"n": state.count, "flag": state.active})'
+```
+
 All custom functions can be called both as functions (`json(x)`) and as methods (`x.json()`).
 
 ### Examples

--- a/sherma/langgraph/declarative/cel_functions.py
+++ b/sherma/langgraph/declarative/cel_functions.py
@@ -150,6 +150,33 @@ def cel_substring(
 
 
 # ---------------------------------------------------------------------------
+# Tier 4: Templating
+# ---------------------------------------------------------------------------
+
+
+def cel_template(
+    text: celtypes.StringType,
+    substitutions: celtypes.MapType,
+) -> celtypes.StringType:
+    """Substitute ``${key}`` placeholders in a string using values from a map.
+
+    Unresolved placeholders (keys not present in the map) are left as-is.
+
+    Usage in CEL::
+
+        template("Hello ${name}!", {"name": "world"})   // "Hello world!"
+
+        // With prompt instructions:
+        template(prompts["plan"]["instructions"], {"skills": state.skill_list})
+    """
+    result = str(text)
+    for key, value in substitutions.items():
+        placeholder = "${" + str(key) + "}"
+        result = result.replace(placeholder, str(value))
+    return celtypes.StringType(result)
+
+
+# ---------------------------------------------------------------------------
 # Registry of all custom functions
 # ---------------------------------------------------------------------------
 
@@ -168,4 +195,6 @@ CUSTOM_FUNCTIONS: dict[str, Any] = {
     "indexOf": cel_index_of,
     "join": cel_join,
     "substring": cel_substring,
+    # Tier 4: Templating
+    "template": cel_template,
 }

--- a/skills/sherma/SKILL.md
+++ b/skills/sherma/SKILL.md
@@ -597,6 +597,10 @@ CEL (Common Expression Language) is used in YAML for dynamic behavior.
 '["a", "b", "c"].join(", ")'                                   # join list → string
 '"hello world".substring(0, 5)'                                # extract substring
 
+# Templating: ${key} substitution from a map
+'template("Hello ${name}!", {"name": state.user})'             # basic substitution
+'template(prompts["plan"]["instructions"], {"skills": state.skill_list})'  # prompt templating
+
 # Combining functions
 'json(state.data.trim())["name"].lowerAscii()'                 # trim → parse → lowercase
 'state.tags.split(",").join(" | ")'                            # split → rejoin
@@ -608,7 +612,7 @@ CEL (Common Expression Language) is used in YAML for dynamic behavior.
 - **String literals need inner quotes**: `'"hello"'` not `'hello'`. Without inner quotes, CEL treats it as a variable name.
 - **`size()` not `len()`**: CEL uses `size()` for list/string length.
 - **Map syntax**: `{"key": value}` — keys must be strings in double quotes.
-- **No f-strings**: Use `+` for concatenation: `'"Count: " + string(count)'`
+- **No f-strings**: Use `template()` for substitution or `+` for concatenation: `template("Count: ${n}", {"n": state.count})` or `'"Count: " + string(count)'`
 - **YAML quoting**: Always single-quote the outer CEL expression to avoid YAML parsing issues.
 - **`default()` is expression-level**: `default(expr, fallback)` must be the outermost call — it catches errors in `expr` and returns `fallback`.
 

--- a/skills/sherma/references/declarative-agents.md
+++ b/skills/sherma/references/declarative-agents.md
@@ -559,6 +559,25 @@ Aligned with the [cel-go strings extension](https://pkg.go.dev/github.com/google
 'json(state.data.trim())["name"].lowerAscii()'
 ```
 
+#### Templating
+
+| Function | Description | Example |
+| --- | --- | --- |
+| `template(string, map)` | Substitute `${key}` placeholders from a map | `template("Hello ${name}!", {"name": "world"})` |
+
+Unresolved placeholders (keys not in the map) are left as-is. Non-string values are coerced to strings.
+
+```yaml
+# Inject state into a prompt template
+'template(prompts["plan-prompt"]["instructions"], {"skill_instructions": state.skill_instructions})'
+
+# Multiple placeholders
+'template("Hello ${name}, your role is ${role}.", {"name": state.user, "role": state.assigned_role})'
+
+# Non-string values are coerced
+'template("Count: ${n}, Active: ${flag}", {"n": state.count, "flag": state.active})'
+```
+
 All custom functions can be called both as functions (`json(x)`) and as methods (`x.json()`).
 
 ### Examples

--- a/tasks/45-prompt-string-templating-with-state-variables.md
+++ b/tasks/45-prompt-string-templating-with-state-variables.md
@@ -1,0 +1,19 @@
+# Task 45: Prompt String Templating with State Variables
+
+## Description
+
+Add a `template(str, map)` CEL function that performs `${key}` substitution from a map, making multi-line prompts with multiple injection points more readable than CEL string concatenation.
+
+## Acceptance Criteria
+
+- [x] Add `template(str, map)` CEL function that performs `${key}` substitution from the map
+- [x] Unresolved placeholders are left as-is (no error)
+- [x] Works with any string, not just prompt references
+- [x] Non-string values are coerced to strings
+- [x] Unit and integration tests added
+- [x] Docs and skill updated
+
+## References
+
+- Issue: https://github.com/MadaraUchiha-314/sherma/issues/45
+- Agent Gateway CEL reference reviewed: no existing `template`/`format` function exists in the community standard

--- a/tasks/plans/45-prompt-string-templating-with-state-variables.md
+++ b/tasks/plans/45-prompt-string-templating-with-state-variables.md
@@ -1,0 +1,22 @@
+# Plan: Prompt String Templating with State Variables
+
+## Investigation
+
+Reviewed the [Agent Gateway CEL reference](https://agentgateway.dev/docs/standalone/latest/reference/cel/#functions-policy-all) and source code (`crates/celx/src/general.rs`, `crates/celx/src/strings.rs`). **No `template`, `format`, `sprintf`, or string interpolation function exists** in Agent Gateway's CEL. The closest are `replace`, `regexReplace`, and `+` concatenation.
+
+## Design Decisions
+
+- **`${key}` syntax**: Matches the issue's YAML example, familiar from shell/ES6 template literals, avoids collision with CEL string syntax.
+- **Unresolved placeholders left as-is**: Safest default for multi-stage composition.
+- **Values are stringified**: `str(value)` on each map value for natural int/bool coercion.
+- **No `$key` (bare dollar) support**: Ambiguous with `$` in natural text. Can add later if needed.
+- **No full templating engine**: Keeps everything in CEL-land without adding Jinja2/Mustache dependency.
+
+## Steps
+
+1. Add `cel_template(text, substitutions)` function to `sherma/langgraph/declarative/cel_functions.py`
+2. Register as `"template"` in `CUSTOM_FUNCTIONS`
+3. Add unit tests in `tests/langgraph/declarative/test_cel_functions.py`
+4. Add integration test with prompt extra_vars in `tests/langgraph/declarative/test_cel_engine.py`
+5. Update docs: `docs/declarative-agents.md`, `skills/sherma/references/declarative-agents.md`, `skills/sherma/SKILL.md`
+6. Create task and plan files

--- a/tests/langgraph/declarative/test_cel_engine.py
+++ b/tests/langgraph/declarative/test_cel_engine.py
@@ -198,3 +198,24 @@ def test_evaluate_state_bracket_access():
     cel = CelEngine()
     result = cel.evaluate('state["x"] + state["y"]', {"x": 10, "y": 20})
     assert result == 30
+
+
+def test_template_with_prompt_extra_vars():
+    """template() works with prompt instructions from extra_vars."""
+    prompt_text = (
+        "You are a helpful assistant.\n\n"
+        "## Available Skills\n"
+        "${skill_instructions}\n\n"
+        "## User Context\n"
+        "${user_context}"
+    )
+    cel = CelEngine(extra_vars={"prompts": {"plan": {"instructions": prompt_text}}})
+    result = cel.evaluate(
+        'template(prompts["plan"]["instructions"], '
+        '{"skill_instructions": state.skills, "user_context": state.ctx})',
+        {"skills": "Use the weather tool.", "ctx": "Location: NYC"},
+    )
+    assert "Use the weather tool." in result
+    assert "Location: NYC" in result
+    assert "${skill_instructions}" not in result
+    assert "${user_context}" not in result

--- a/tests/langgraph/declarative/test_cel_functions.py
+++ b/tests/langgraph/declarative/test_cel_functions.py
@@ -300,6 +300,76 @@ class TestSubstring:
 
 
 # ---------------------------------------------------------------------------
+# Tier 4: template()
+# ---------------------------------------------------------------------------
+
+
+class TestTemplate:
+    def test_basic_substitution(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate('template("Hello ${name}!", {"name": "world"})', {})
+        assert result == "Hello world!"
+
+    def test_multiple_placeholders(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template("${greeting}, ${name}!", {"greeting": "Hi", "name": "Alice"})',
+            {},
+        )
+        assert result == "Hi, Alice!"
+
+    def test_unresolved_placeholders_left_as_is(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template("Hello ${name}, your role is ${role}.", {"name": "Bob"})',
+            {},
+        )
+        assert result == "Hello Bob, your role is ${role}."
+
+    def test_empty_map(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate('template("Hello ${name}!", {})', {})
+        assert result == "Hello ${name}!"
+
+    def test_non_string_values(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template("count=${count}, flag=${flag}", {"count": 42, "flag": true})',
+            {},
+        )
+        assert result == "count=42, flag=True"
+
+    def test_empty_string_template(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate('template("", {"key": "value"})', {})
+        assert result == ""
+
+    def test_repeated_placeholder(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template("${x} and ${x}", {"x": "same"})',
+            {},
+        )
+        assert result == "same and same"
+
+    def test_with_state_values(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template("Welcome ${user}!", {"user": state.username})',
+            {"username": "Charlie"},
+        )
+        assert result == "Welcome Charlie!"
+
+    def test_multiline_template(self) -> None:
+        cel = CelEngine()
+        result = cel.evaluate(
+            'template(state.tpl, {"a": "first", "b": "second"})',
+            {"tpl": "Line1: ${a}\nLine2: ${b}"},
+        )
+        assert result == "Line1: first\nLine2: second"
+
+
+# ---------------------------------------------------------------------------
 # Integration: combining functions
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds a `template(str, map)` CEL function that performs `${key}` placeholder substitution from a map, making multi-line prompts with multiple injection points far more readable than CEL string concatenation
- Unresolved placeholders (keys not in the map) are left as-is; non-string values are coerced to strings
- Investigated [Agent Gateway CEL reference](https://agentgateway.dev/docs/standalone/latest/reference/cel/) — no existing `template`/`format`/`sprintf` function exists in the community standard, so this is a new addition

### Example usage
```yaml
nodes:
  - name: plan
    type: call_llm
    args:
      prompt:
        - role: system
          content: 'template(prompts["plan-prompt"]["instructions"], {"skill_instructions": state.skill_instructions})'
```

## Test plan

- [x] 9 unit tests for `template()`: basic substitution, multiple placeholders, unresolved keys left as-is, empty map, non-string values, empty string, repeated placeholders, state values, multiline templates
- [x] 1 integration test via `CelEngine` with prompt `extra_vars` mirroring real YAML usage
- [x] All 525 unit tests pass, 0 pyright errors on changed files
- [x] Docs updated: `docs/declarative-agents.md`, `skills/sherma/SKILL.md`, `skills/sherma/references/declarative-agents.md`

Closes #45

https://claude.ai/code/session_01PK3Zpz9ecvygF2PGkJmNh4