### PR TITLE
feat: add mcp_servers and env-var interpolation to declarative YAML

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -382,6 +382,7 @@ class DeclarativeConfig(BaseModel):
     skills: list[SkillDef] = []
     hooks: list[HookDef] = []
     sub_agents: list[SubAgentDef] = []
+    mcp_servers: list[MCPServerDef] = []
     default_llm: RegistryRef | None = None
     checkpointer: CheckpointerDef | None = None
 ```
@@ -423,6 +424,37 @@ class CheckpointerDef(BaseModel):
     type: Literal["memory"] = "memory"
 ```
 
+### `MCPServerDef` (declarative YAML)
+
+Top-level `mcp_servers:` entry — distinct from the same-named class
+under `sherma.entities.skill_card`, which models MCP servers embedded
+in a skill card. This one lives in
+`sherma.langgraph.declarative.schema`.
+
+```python
+class MCPServerDef(BaseModel):
+    id: str
+    version: str = "*"
+    transport: Literal["streamable_http", "sse", "stdio"] = "streamable_http"
+    # streamable_http / sse
+    url: str | None = None
+    headers: dict[str, str] = {}
+    # stdio
+    command: str | None = None
+    args: list[str] = []
+    env: dict[str, str] = {}
+    # Optional renaming to avoid name collisions across servers
+    tool_prefix: str | None = None
+```
+
+For HTTP-based transports, set `url` (and optionally `headers`).
+For `stdio`, set `command` (and optionally `args` / `env`).
+At config-load time sherma connects to each declared server,
+lists its tools, and registers them in the tool registry — making
+them usable from `call_llm` nodes via `tools:` or
+`use_tools_from_registry: true`. When `tool_prefix` is set, each
+tool is registered as `<tool_prefix><tool_name>`.
+
 ### `load_declarative_config`
 
 ```python
@@ -431,6 +463,16 @@ def load_declarative_config(
     yaml_content: str | None = None,
 ) -> DeclarativeConfig
 ```
+
+Before the YAML data is validated, every string value is passed
+through environment-variable interpolation: `${VAR}` is replaced
+with `os.environ["VAR"]`, `${VAR:-default}` falls back to `default`
+when the variable is unset, and `$$` becomes a literal `$`. Only
+`UPPERCASE_WITH_UNDERSCORES` names are matched, so lowercase
+placeholders intended for the CEL `template()` function (e.g.
+`${available_skills}`) pass through untouched. Missing required
+variables raise `DeclarativeConfigError` listing all unresolved
+names.
 
 ## Schema Utilities
 

--- a/docs/declarative-agents.md
+++ b/docs/declarative-agents.md
@@ -13,6 +13,7 @@ llms:         # LLM declarations
 tools:        # Tool imports
 skills:       # Skill card references
 sub_agents:   # Sub-agent declarations (for multi-agent orchestration)
+mcp_servers:  # MCP server declarations (tools auto-registered)
 hooks:        # Hook executor imports
 checkpointer: # Checkpointer configuration (for state persistence)
 default_llm:  # Default LLM for call_llm nodes (optional)
@@ -30,6 +31,44 @@ manifest_version: 1
 ```
 
 All entity registrations and the graph definition live in one file, giving you a complete snapshot of the agent.
+
+### Environment-variable interpolation
+
+Every string value in the YAML supports environment-variable
+substitution. This lets you keep secrets and per-environment values
+(URLs, tokens, model names) out of source control without templating
+the YAML yourself.
+
+| Syntax | Behaviour |
+| --- | --- |
+| `${VAR}` | Replaced with `os.environ["VAR"]` |
+| `${VAR:-default}` | Replaced with `default` if `VAR` is unset |
+| `$$` | Literal `$` — not processed as a substitution |
+
+Only `UPPERCASE_WITH_UNDERSCORES` names are treated as environment
+variables. Lowercase placeholders such as `${available_skills}` are
+**not** substituted at YAML-load time and remain available to the CEL
+`template()` function at runtime.
+
+Missing required variables (no default) raise
+`DeclarativeConfigError` with all unresolved names listed.
+Substitution happens **before** Pydantic validation, so the
+substituted values are validated like any other YAML input.
+
+```yaml
+llms:
+  - id: openai
+    version: "1.0.0"
+    provider: openai
+    model_name: ${OPENAI_MODEL:-gpt-4o-mini}
+
+mcp_servers:
+  - id: factset
+    transport: streamable_http
+    url: ${FACTSET_MCP_URL}
+    headers:
+      Authorization: "Bearer ${FACTSET_TOKEN}"
+```
 
 ## Entity Declarations
 
@@ -134,6 +173,81 @@ sub_agents:
     version: "1.0.0"
     # No source -- expects the agent to already be in the registry
 ```
+
+### MCP Servers
+
+Declare [Model Context Protocol](https://modelcontextprotocol.io)
+servers in YAML; sherma connects, lists each server's tools, and
+registers them in the tool registry. The tools are then usable from
+`call_llm` nodes via the standard tool-binding mechanisms (`tools:`
+list, `use_tools_from_registry: true`).
+
+```yaml
+mcp_servers:
+  # HTTP / streamable-HTTP server
+  - id: factset
+    version: "1.0.0"
+    transport: streamable_http               # or "sse"
+    url: ${FACTSET_MCP_URL}
+    headers:
+      Authorization: "Bearer ${FACTSET_TOKEN}"
+    tool_prefix: "factset__"                  # optional, namespaces registered tool ids
+
+  # Local stdio server
+  - id: filesystem
+    version: "1.0.0"
+    transport: stdio
+    command: uvx
+    args: ["mcp-server-filesystem", "--root", "."]
+    env:
+      LOG_LEVEL: info
+```
+
+| Field | Required for | Description |
+| --- | --- | --- |
+| `id` | All | Server identifier (used by `tool_prefix` and error messages). |
+| `version` | All | Used as the `version` of every registered tool from this server. |
+| `transport` | All | `streamable_http` (default), `sse`, or `stdio`. |
+| `url` | HTTP / SSE | Server URL. May contain `${VAR}` substitutions. |
+| `headers` | HTTP / SSE | Optional request headers. |
+| `command` | stdio | Executable to launch. |
+| `args` | stdio | Arguments to pass to `command`. |
+| `env` | stdio | Extra environment variables for the spawned process. |
+| `tool_prefix` | optional | Prefix prepended to every registered tool's id. |
+
+**Tool registration**: each tool returned by the MCP server is wrapped
+as a sherma `Tool` whose `id` equals `<tool_prefix><tool_name>` and
+whose version equals the server's `version`. Use `tool_prefix` when
+two MCP servers expose tools with the same name, or when you want a
+single binding mode (`use_tools_from_registry: true`) to coexist with
+non-MCP tools whose names you control.
+
+```yaml
+agents:
+  earnings-reviewer:
+    state:
+      fields:
+        - { name: messages, type: list, default: [] }
+    graph:
+      entry_point: agent
+      nodes:
+        - name: agent
+          type: call_llm
+          args:
+            prompt:
+              - { role: system, content: 'prompts["er"]["instructions"]' }
+              - { role: messages, content: 'state.messages' }
+            use_tools_from_registry: true   # picks up MCP tools too
+            state_updates: { messages: '[llm_response]' }
+      edges:
+        - { source: agent, target: __end__ }
+```
+
+> **Note**: the `MCPServerDef` used here lives in
+> `sherma.langgraph.declarative.schema` and is distinct from the
+> identically named `MCPServerDef` in
+> `sherma.entities.skill_card`, which models MCP servers embedded in
+> a skill card.
 
 ### Checkpointer
 

--- a/sherma/langgraph/declarative/loader.py
+++ b/sherma/langgraph/declarative/loader.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -21,6 +23,7 @@ from sherma.hooks.manager import HookManager
 from sherma.langgraph.declarative.schema import (
     CallLLMArgs,
     DeclarativeConfig,
+    MCPServerDef,
 )
 from sherma.langgraph.tools import agent_to_langgraph_tool, from_langgraph_tool
 from sherma.registry.base import RegistryEntry
@@ -57,6 +60,68 @@ class LazyChatModel:
         return "LazyChatModel(pending)"
 
 
+_ENV_VAR_PATTERN = re.compile(
+    r"\$(?P<escape>\$)|\$\{(?P<name>[A-Z_][A-Z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
+
+
+def _interpolate_env_vars(
+    data: Any,
+    *,
+    environ: dict[str, str] | None = None,
+) -> Any:
+    """Recursively substitute ``${VAR}`` / ``${VAR:-default}`` in strings.
+
+    Only ``UPPERCASE_WITH_UNDERSCORES`` names are treated as environment
+    variables; lowercase placeholders (e.g. ``${available_skills}``) are
+    left untouched so they remain available to the CEL ``template()``
+    function at runtime.
+
+    A literal ``$`` can be written as ``$$``. Missing variables without a
+    default are collected and reported as a single
+    :class:`DeclarativeConfigError`.
+
+    Non-string scalars and the structure of dicts/lists are preserved
+    verbatim.
+    """
+    env = os.environ if environ is None else environ
+    missing: list[str] = []
+
+    def _sub(value: str) -> str:
+        def _replace(m: re.Match[str]) -> str:
+            if m.group("escape"):
+                return "$"
+            name = m.group("name")
+            assert name is not None
+            default = m.group("default")
+            if name in env:
+                return env[name]
+            if default is not None:
+                return default
+            missing.append(name)
+            return ""
+
+        return _ENV_VAR_PATTERN.sub(_replace, value)
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, str):
+            return _sub(node)
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    result = _walk(data)
+    if missing:
+        unique = sorted(dict.fromkeys(missing))
+        raise DeclarativeConfigError(
+            "Unresolved environment variable(s) in YAML: "
+            + ", ".join(f"${{{n}}}" for n in unique)
+        )
+    return result
+
+
 def load_declarative_config(
     yaml_path: str | Path | None = None,
     yaml_content: str | None = None,
@@ -64,6 +129,9 @@ def load_declarative_config(
     """Load and validate a declarative config from YAML.
 
     Provide either yaml_path or yaml_content, not both.
+
+    String values support ``${VAR}`` and ``${VAR:-default}`` substitution
+    from the process environment. Use ``$$`` to write a literal ``$``.
     """
     if yaml_path is not None and yaml_content is not None:
         raise DeclarativeConfigError(
@@ -87,6 +155,8 @@ def load_declarative_config(
 
     if not isinstance(data, dict):
         raise DeclarativeConfigError("YAML root must be a mapping")
+
+    data = _interpolate_env_vars(data)
 
     return _parse_config(data)
 
@@ -268,6 +338,69 @@ def create_chat_model(
     """
     kwargs = _build_chat_model_kwargs(provider, model_name, http_async_client)
     return _construct_chat_model(provider, kwargs)
+
+
+def _build_mcp_connection(server: MCPServerDef) -> dict[str, Any]:
+    """Build a langchain-mcp-adapters connection dict for one MCP server."""
+    if server.transport == "stdio":
+        conn: dict[str, Any] = {
+            "transport": "stdio",
+            "command": server.command,
+            "args": list(server.args),
+        }
+        if server.env:
+            conn["env"] = dict(server.env)
+        return conn
+
+    conn = {"transport": server.transport, "url": server.url}
+    if server.headers:
+        conn["headers"] = dict(server.headers)
+    return conn
+
+
+async def _register_mcp_servers(
+    servers: list[MCPServerDef],
+    registries: RegistryBundle,
+    tenant_id: str,
+) -> None:
+    """Connect to declared MCP servers and register their tools."""
+    if not servers:
+        return
+
+    try:
+        from langchain_mcp_adapters.client import MultiServerMCPClient
+    except ImportError as exc:  # pragma: no cover - dependency is required
+        raise DeclarativeConfigError(
+            "langchain-mcp-adapters is required for 'mcp_servers'. "
+            "Install with: uv add langchain-mcp-adapters"
+        ) from exc
+
+    connections = {s.id: _build_mcp_connection(s) for s in servers}
+    client = MultiServerMCPClient(connections)  # type: ignore[arg-type]
+
+    for server in servers:
+        try:
+            mcp_tools = await client.get_tools(server_name=server.id)
+        except Exception as exc:
+            raise DeclarativeConfigError(
+                f"Failed to load tools from MCP server '{server.id}': {exc}"
+            ) from exc
+
+        for lg_tool in mcp_tools:
+            if server.tool_prefix:
+                lg_tool.name = f"{server.tool_prefix}{lg_tool.name}"
+            sherma_tool = from_langgraph_tool(lg_tool)
+            sherma_tool.id = lg_tool.name
+            sherma_tool.version = server.version
+            sherma_tool.tenant_id = tenant_id
+            await registries.tool_registry.add(
+                RegistryEntry(
+                    id=sherma_tool.id,
+                    version=server.version,
+                    tenant_id=tenant_id,
+                    instance=sherma_tool,
+                )
+            )
 
 
 async def populate_registries(
@@ -489,6 +622,9 @@ async def populate_registries(
                                 instance=sherma_tool,
                             )
                         )
+
+    # Connect to MCP servers and register their tools
+    await _register_mcp_servers(config.mcp_servers, registries, tenant_id)
 
     # Auto-import tools declared with import_path
     for tool_def in config.tools:

--- a/sherma/langgraph/declarative/schema.py
+++ b/sherma/langgraph/declarative/schema.py
@@ -386,6 +386,57 @@ class CheckpointerDef(BaseModel):
     type: Literal["memory"] = "memory"
 
 
+class MCPServerDef(BaseModel):
+    """An MCP (Model Context Protocol) server declaration in the YAML.
+
+    Tools exposed by the server are listed at config-load time and
+    registered into the tool registry, making them usable from
+    ``call_llm`` nodes via ``tools:`` or
+    ``use_tools_from_registry: true``.
+
+    For HTTP-based transports (``streamable_http``, ``sse``), set
+    ``url`` (and optionally ``headers``). For ``stdio``, set ``command``
+    (and optionally ``args`` / ``env``). Set ``tool_prefix`` to namespace
+    the registered tools and avoid collisions across servers.
+    """
+
+    id: str
+    version: str = "*"
+    transport: Literal["streamable_http", "sse", "stdio"] = "streamable_http"
+    url: str | None = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    tool_prefix: str | None = None
+
+    @model_validator(mode="after")
+    def _check_transport_fields(self) -> Self:
+        if self.transport in ("streamable_http", "sse"):
+            if not self.url:
+                raise ValueError(
+                    f"MCPServerDef '{self.id}' with transport "
+                    f"'{self.transport}' requires 'url'"
+                )
+            if self.command:
+                raise ValueError(
+                    f"MCPServerDef '{self.id}' with transport "
+                    f"'{self.transport}' must not set 'command'"
+                )
+        else:  # stdio
+            if not self.command:
+                raise ValueError(
+                    f"MCPServerDef '{self.id}' with transport 'stdio' "
+                    f"requires 'command'"
+                )
+            if self.url:
+                raise ValueError(
+                    f"MCPServerDef '{self.id}' with transport 'stdio' "
+                    f"must not set 'url'"
+                )
+        return self
+
+
 class DeclarativeConfig(BaseModel):
     """Top-level declarative configuration parsed from YAML."""
 
@@ -397,5 +448,6 @@ class DeclarativeConfig(BaseModel):
     skills: list[SkillDef] = Field(default_factory=list)
     hooks: list[HookDef] = Field(default_factory=list)
     sub_agents: list[SubAgentDef] = Field(default_factory=list)
+    mcp_servers: list[MCPServerDef] = Field(default_factory=list)
     default_llm: RegistryRef | None = None
     checkpointer: CheckpointerDef | None = None

--- a/skills/sherma/SKILL.md
+++ b/skills/sherma/SKILL.md
@@ -49,6 +49,7 @@ llms:          # LLM declarations (id, version, provider, model_name)
 tools:         # Tool imports (id, version, import_path)
 skills:        # Skill card references (id, version, skill_card_path or url)
 sub_agents:    # Sub-agent declarations (id, version, yaml_path/import_path/url)
+mcp_servers:   # MCP server declarations (auto-registers tools into the registry)
 hooks:         # Hook executor imports (import_path or url)
 checkpointer:  # Checkpointer config (type: memory)
 default_llm:   # Default LLM for call_llm nodes (id reference)
@@ -144,6 +145,29 @@ Dynamic flags are mutually exclusive with each other, but an explicit `tools` li
 **Auto-injected tool_node**: When a `call_llm` node has tools, sherma auto-injects a `tool_node` after it with conditional edges. You do NOT wire this manually.
 
 **`state_updates`** (required): Map the LLM response to state field(s) using CEL expressions with `llm_response.content` and `llm_response.tool_calls`. Values are **deltas** passed to LangGraph reducers. The standard pattern is `messages: '[llm_response]'`. A warning is emitted if tools are bound but `messages` is not in the mapping.
+
+### MCP servers
+
+Top-level `mcp_servers:` declarations connect to MCP servers and register their tools into the global tool registry, where they are picked up by `tools: [{id, version}]` or `use_tools_from_registry: true`.
+
+```yaml
+mcp_servers:
+  - id: factset
+    transport: streamable_http     # or "sse" / "stdio"
+    url: ${FACTSET_MCP_URL}
+    headers: { Authorization: "Bearer ${FACTSET_TOKEN}" }
+    tool_prefix: "factset__"        # optional, namespaces tool ids
+  - id: filesystem
+    transport: stdio
+    command: uvx
+    args: ["mcp-server-filesystem"]
+```
+
+Required fields: `url` for `streamable_http` / `sse`; `command` for `stdio`. Each registered tool gets `id = <tool_prefix><tool_name>` and `version = <server.version>`.
+
+### Environment-variable interpolation
+
+Every YAML string supports `${VAR}` and `${VAR:-default}` for `UPPERCASE_WITH_UNDERSCORES` names. Use `$$` for a literal `$`. Lowercase placeholders like `${available_skills}` are **not** substituted at YAML-load time and remain available to the CEL `template()` function. Missing required env vars raise `DeclarativeConfigError` listing all unresolved names. Interpolation runs **before** Pydantic validation.
 
 ## Quick Reference: Programmatic Agent
 

--- a/skills/sherma/references/api-reference.md
+++ b/skills/sherma/references/api-reference.md
@@ -382,6 +382,7 @@ class DeclarativeConfig(BaseModel):
     skills: list[SkillDef] = []
     hooks: list[HookDef] = []
     sub_agents: list[SubAgentDef] = []
+    mcp_servers: list[MCPServerDef] = []
     default_llm: RegistryRef | None = None
     checkpointer: CheckpointerDef | None = None
 ```
@@ -423,6 +424,37 @@ class CheckpointerDef(BaseModel):
     type: Literal["memory"] = "memory"
 ```
 
+### `MCPServerDef` (declarative YAML)
+
+Top-level `mcp_servers:` entry — distinct from the same-named class
+under `sherma.entities.skill_card`, which models MCP servers embedded
+in a skill card. This one lives in
+`sherma.langgraph.declarative.schema`.
+
+```python
+class MCPServerDef(BaseModel):
+    id: str
+    version: str = "*"
+    transport: Literal["streamable_http", "sse", "stdio"] = "streamable_http"
+    # streamable_http / sse
+    url: str | None = None
+    headers: dict[str, str] = {}
+    # stdio
+    command: str | None = None
+    args: list[str] = []
+    env: dict[str, str] = {}
+    # Optional renaming to avoid name collisions across servers
+    tool_prefix: str | None = None
+```
+
+For HTTP-based transports, set `url` (and optionally `headers`).
+For `stdio`, set `command` (and optionally `args` / `env`).
+At config-load time sherma connects to each declared server,
+lists its tools, and registers them in the tool registry — making
+them usable from `call_llm` nodes via `tools:` or
+`use_tools_from_registry: true`. When `tool_prefix` is set, each
+tool is registered as `<tool_prefix><tool_name>`.
+
 ### `load_declarative_config`
 
 ```python
@@ -431,6 +463,16 @@ def load_declarative_config(
     yaml_content: str | None = None,
 ) -> DeclarativeConfig
 ```
+
+Before the YAML data is validated, every string value is passed
+through environment-variable interpolation: `${VAR}` is replaced
+with `os.environ["VAR"]`, `${VAR:-default}` falls back to `default`
+when the variable is unset, and `$$` becomes a literal `$`. Only
+`UPPERCASE_WITH_UNDERSCORES` names are matched, so lowercase
+placeholders intended for the CEL `template()` function (e.g.
+`${available_skills}`) pass through untouched. Missing required
+variables raise `DeclarativeConfigError` listing all unresolved
+names.
 
 ## Schema Utilities
 

--- a/skills/sherma/references/declarative-agents.md
+++ b/skills/sherma/references/declarative-agents.md
@@ -13,6 +13,7 @@ llms:         # LLM declarations
 tools:        # Tool imports
 skills:       # Skill card references
 sub_agents:   # Sub-agent declarations (for multi-agent orchestration)
+mcp_servers:  # MCP server declarations (tools auto-registered)
 hooks:        # Hook executor imports
 checkpointer: # Checkpointer configuration (for state persistence)
 default_llm:  # Default LLM for call_llm nodes (optional)
@@ -30,6 +31,44 @@ manifest_version: 1
 ```
 
 All entity registrations and the graph definition live in one file, giving you a complete snapshot of the agent.
+
+### Environment-variable interpolation
+
+Every string value in the YAML supports environment-variable
+substitution. This lets you keep secrets and per-environment values
+(URLs, tokens, model names) out of source control without templating
+the YAML yourself.
+
+| Syntax | Behaviour |
+| --- | --- |
+| `${VAR}` | Replaced with `os.environ["VAR"]` |
+| `${VAR:-default}` | Replaced with `default` if `VAR` is unset |
+| `$$` | Literal `$` — not processed as a substitution |
+
+Only `UPPERCASE_WITH_UNDERSCORES` names are treated as environment
+variables. Lowercase placeholders such as `${available_skills}` are
+**not** substituted at YAML-load time and remain available to the CEL
+`template()` function at runtime.
+
+Missing required variables (no default) raise
+`DeclarativeConfigError` with all unresolved names listed.
+Substitution happens **before** Pydantic validation, so the
+substituted values are validated like any other YAML input.
+
+```yaml
+llms:
+  - id: openai
+    version: "1.0.0"
+    provider: openai
+    model_name: ${OPENAI_MODEL:-gpt-4o-mini}
+
+mcp_servers:
+  - id: factset
+    transport: streamable_http
+    url: ${FACTSET_MCP_URL}
+    headers:
+      Authorization: "Bearer ${FACTSET_TOKEN}"
+```
 
 ## Entity Declarations
 
@@ -134,6 +173,81 @@ sub_agents:
     version: "1.0.0"
     # No source -- expects the agent to already be in the registry
 ```
+
+### MCP Servers
+
+Declare [Model Context Protocol](https://modelcontextprotocol.io)
+servers in YAML; sherma connects, lists each server's tools, and
+registers them in the tool registry. The tools are then usable from
+`call_llm` nodes via the standard tool-binding mechanisms (`tools:`
+list, `use_tools_from_registry: true`).
+
+```yaml
+mcp_servers:
+  # HTTP / streamable-HTTP server
+  - id: factset
+    version: "1.0.0"
+    transport: streamable_http               # or "sse"
+    url: ${FACTSET_MCP_URL}
+    headers:
+      Authorization: "Bearer ${FACTSET_TOKEN}"
+    tool_prefix: "factset__"                  # optional, namespaces registered tool ids
+
+  # Local stdio server
+  - id: filesystem
+    version: "1.0.0"
+    transport: stdio
+    command: uvx
+    args: ["mcp-server-filesystem", "--root", "."]
+    env:
+      LOG_LEVEL: info
+```
+
+| Field | Required for | Description |
+| --- | --- | --- |
+| `id` | All | Server identifier (used by `tool_prefix` and error messages). |
+| `version` | All | Used as the `version` of every registered tool from this server. |
+| `transport` | All | `streamable_http` (default), `sse`, or `stdio`. |
+| `url` | HTTP / SSE | Server URL. May contain `${VAR}` substitutions. |
+| `headers` | HTTP / SSE | Optional request headers. |
+| `command` | stdio | Executable to launch. |
+| `args` | stdio | Arguments to pass to `command`. |
+| `env` | stdio | Extra environment variables for the spawned process. |
+| `tool_prefix` | optional | Prefix prepended to every registered tool's id. |
+
+**Tool registration**: each tool returned by the MCP server is wrapped
+as a sherma `Tool` whose `id` equals `<tool_prefix><tool_name>` and
+whose version equals the server's `version`. Use `tool_prefix` when
+two MCP servers expose tools with the same name, or when you want a
+single binding mode (`use_tools_from_registry: true`) to coexist with
+non-MCP tools whose names you control.
+
+```yaml
+agents:
+  earnings-reviewer:
+    state:
+      fields:
+        - { name: messages, type: list, default: [] }
+    graph:
+      entry_point: agent
+      nodes:
+        - name: agent
+          type: call_llm
+          args:
+            prompt:
+              - { role: system, content: 'prompts["er"]["instructions"]' }
+              - { role: messages, content: 'state.messages' }
+            use_tools_from_registry: true   # picks up MCP tools too
+            state_updates: { messages: '[llm_response]' }
+      edges:
+        - { source: agent, target: __end__ }
+```
+
+> **Note**: the `MCPServerDef` used here lives in
+> `sherma.langgraph.declarative.schema` and is distinct from the
+> identically named `MCPServerDef` in
+> `sherma.entities.skill_card`, which models MCP servers embedded in
+> a skill card.
 
 ### Checkpointer
 

--- a/tasks/74-mcp-and-env-var-interpolation.md
+++ b/tasks/74-mcp-and-env-var-interpolation.md
@@ -1,0 +1,43 @@
+# Task 74: First-class MCP support and env-var interpolation in YAML
+
+GitHub Issue: https://github.com/MadaraUchiha-314/sherma/issues/74
+
+## Problem
+
+Two related gaps surfaced while comparing sherma's `agent.yaml` to Claude
+Managed Agents' `agent.yaml` (see issue #74):
+
+1. **No first-class MCP support in YAML.** Sherma already depends on
+   `mcp` and `langchain-mcp-adapters`, but a declarative agent cannot
+   point at an MCP server and pull its tools into the tool registry
+   without writing Python glue code. Claude's manifest exposes
+   `mcp_servers:` and a `mcp_toolset` binding directly in YAML.
+
+2. **No environment-variable interpolation in YAML.** Production
+   manifests inevitably reference URLs, tokens, and per-environment
+   values that should not be checked in. Claude's manifest supports
+   `${VAR}`-style substitution (e.g., `url: "${FACTSET_MCP_URL}"`).
+   Sherma users currently have to template the YAML themselves.
+
+## Goal
+
+Land both improvements in a single PR so users can write MCP-backed
+agents with environment-driven configuration in pure YAML.
+
+### Feature 1 — `mcp_servers:` in YAML
+
+Add a top-level `mcp_servers:` section. Each entry declares an MCP
+server (HTTP/SSE/stdio); on config load sherma connects, lists tools,
+and registers each tool in the tool registry. The tools become usable
+from `call_llm` nodes via the existing tool-binding mechanisms
+(`tools:` list, `use_tools_from_registry: true`).
+
+### Feature 2 — `${VAR}` interpolation in YAML
+
+Substitute `${VAR}` and `${VAR:-default}` in any string value before
+the YAML is parsed into Pydantic models. Missing required variables
+raise `DeclarativeConfigError` with a list of unresolved names.
+
+## Chat Iterations
+
+_None yet._

--- a/tasks/plans/74-mcp-and-env-var-interpolation.md
+++ b/tasks/plans/74-mcp-and-env-var-interpolation.md
@@ -1,0 +1,124 @@
+# Plan 74: First-class MCP support and env-var interpolation in YAML
+
+## Steps
+
+### Part A — Env-var interpolation (`${VAR}` / `${VAR:-default}`)
+
+1. **Add `_interpolate_env_vars` helper in
+   `sherma/langgraph/declarative/loader.py`.**
+   - Operate on the parsed Python data (dict/list/scalar tree) returned
+     by `yaml.safe_load`, not on the raw YAML text — this keeps YAML
+     syntax intact and only substitutes within string values.
+   - Pattern: `\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}` matches
+     `${VAR}` and `${VAR:-default}`. Multiple substitutions per string
+     are supported.
+   - Escape: a literal `$$` becomes a single `$` and is not processed.
+   - Missing `${VAR}` (with no default) accumulates the variable name.
+     If any are missing, raise `DeclarativeConfigError` listing all
+     missing names.
+   - Recurse into dicts and lists; leave non-string scalars alone.
+
+2. **Call the helper from `load_declarative_config`** right after
+   `yaml.safe_load` and before `_parse_config`.
+
+3. **Tests** — `tests/langgraph/declarative/test_env_interpolation.py`
+   (new file):
+   - Substitute `${VAR}` from `monkeypatch.setenv`.
+   - Default fallback `${VAR:-foo}` when var is unset.
+   - Missing required var raises with all missing names listed.
+   - Substitution inside nested dicts and lists.
+   - `$$` escapes a literal `$`.
+   - Strings with no `${...}` pass through untouched.
+
+### Part B — First-class MCP support
+
+1. **Schema (`sherma/langgraph/declarative/schema.py`).**
+   Add `MCPServerDef`:
+   ```python
+   class MCPServerDef(BaseModel):
+       id: str
+       version: str = "*"
+       transport: Literal["streamable_http", "sse", "stdio"] = "streamable_http"
+       # HTTP/SSE
+       url: str | None = None
+       headers: dict[str, str] = Field(default_factory=dict)
+       # stdio
+       command: str | None = None
+       args: list[str] = Field(default_factory=list)
+       env: dict[str, str] = Field(default_factory=dict)
+       # Optional rename to avoid collisions across servers
+       tool_prefix: str | None = None
+   ```
+   Add a `model_validator` that requires `url` for HTTP transports and
+   `command` for stdio.
+   Add `mcp_servers: list[MCPServerDef] = Field(default_factory=list)`
+   to `DeclarativeConfig`.
+
+2. **Loader (`sherma/langgraph/declarative/loader.py`).**
+   - Add `_register_mcp_servers(config, registries, tenant_id)`:
+     - Build a `MultiServerMCPClient` connection dict per server using
+       `langchain_mcp_adapters.client.MultiServerMCPClient`.
+     - For each server, call `await client.get_tools(server_name=...)`
+       to fetch its tool list.
+     - For each LangChain `BaseTool` returned, optionally rename to
+       `<tool_prefix><tool_name>`, then wrap via `from_langgraph_tool`,
+       set tenant_id, and add to `registries.tool_registry` with
+       `id=<final_name>` and `version=server.version`.
+   - Call this helper from `populate_registries` after LLM/prompt
+     registration but before tools / sub-agents (so MCP tools are in
+     the registry by the time other entities load).
+   - Wrap connection failures in `DeclarativeConfigError`.
+
+3. **Tests** — `tests/langgraph/declarative/test_mcp_servers.py`
+   (new file). Cover purely loader-level behaviour by
+   monkeypatching `MultiServerMCPClient.get_tools` to return a fake
+   tool list:
+   - `mcp_servers` empty / absent: no-op.
+   - HTTP server: tools registered with raw names.
+   - `tool_prefix` applied to registered ids.
+   - stdio server config: stub-tested for connection-dict shape.
+   - Schema validator: HTTP without `url` raises; stdio without
+     `command` raises.
+
+4. **Schema enforcement note** — keep the changes additive: existing
+   YAMLs without `mcp_servers:` continue to work unchanged.
+
+### Part C — Docs and skill (always required by `CLAUDE.md`)
+
+1. **`docs/declarative-agents.md`** — add two new sections:
+   - "Environment-variable interpolation" near the top (under
+     "YAML Structure"), with examples of `${VAR}` and
+     `${VAR:-default}` and the `$$` escape.
+   - "MCP servers" alongside "Tools" / "Skills", showing the YAML
+     shape for HTTP and stdio servers and how the resulting tools are
+     consumed by `call_llm` (via `tools:` or
+     `use_tools_from_registry: true`).
+2. **`docs/api-reference.md`** — add the `MCPServerDef` Pydantic shape
+   and the new `mcp_servers` field on `DeclarativeConfig`.
+3. **Mirror to `skills/sherma/references/declarative-agents.md` and
+   `skills/sherma/references/api-reference.md`** (these are docs
+   copies per `CLAUDE.md`).
+4. **`skills/sherma/SKILL.md`** — add `mcp_servers:` to the top-level
+   keys list and a one-line note on `${VAR}` interpolation in the
+   "Quick Reference" / gotchas section.
+
+### Part D — Verification
+
+1. `uv run ruff check .`
+2. `uv run ruff format --check .`
+3. `uv run pyright`
+4. `uv run pytest -m "not integration"`
+
+### Part E — Commit & PR
+
+1. Conventional-commit message: `feat: add MCP servers and env-var
+   interpolation in declarative YAML`.
+2. Push to `claude/fix-issue-74-bqsmJ` (the branch the harness has
+   pre-assigned for issue #74).
+3. Open PR titled `feat: add MCP servers and env-var interpolation in
+   declarative YAML`, body referencing issue #74 and describing both
+   features.
+
+## Plan Revisions
+
+_None yet._

--- a/tests/langgraph/declarative/test_env_interpolation.py
+++ b/tests/langgraph/declarative/test_env_interpolation.py
@@ -1,0 +1,164 @@
+"""Tests for ``${VAR}`` environment-variable interpolation in YAML."""
+
+from __future__ import annotations
+
+import pytest
+
+from sherma.exceptions import DeclarativeConfigError
+from sherma.langgraph.declarative.loader import (
+    _interpolate_env_vars,
+    load_declarative_config,
+)
+
+
+def test_substitutes_set_variable() -> None:
+    result = _interpolate_env_vars(
+        {"url": "${MY_URL}/path"},
+        environ={"MY_URL": "https://example.com"},
+    )
+    assert result == {"url": "https://example.com/path"}
+
+
+def test_default_used_when_var_unset() -> None:
+    result = _interpolate_env_vars(
+        {"url": "${MY_URL:-https://default.example.com}"},
+        environ={},
+    )
+    assert result == {"url": "https://default.example.com"}
+
+
+def test_default_ignored_when_var_set() -> None:
+    result = _interpolate_env_vars(
+        {"url": "${MY_URL:-fallback}"},
+        environ={"MY_URL": "real"},
+    )
+    assert result == {"url": "real"}
+
+
+def test_missing_required_var_raises_with_all_names() -> None:
+    with pytest.raises(DeclarativeConfigError) as exc:
+        _interpolate_env_vars(
+            {"a": "${MISSING_ONE}", "b": ["${MISSING_TWO}", "${MISSING_ONE}"]},
+            environ={},
+        )
+    msg = str(exc.value)
+    assert "${MISSING_ONE}" in msg
+    assert "${MISSING_TWO}" in msg
+
+
+def test_recurses_through_dicts_and_lists() -> None:
+    result = _interpolate_env_vars(
+        {
+            "outer": {
+                "inner": "${A}",
+                "list": ["plain", "${B}", {"deep": "${A}-${B}"}],
+            }
+        },
+        environ={"A": "1", "B": "2"},
+    )
+    assert result == {
+        "outer": {
+            "inner": "1",
+            "list": ["plain", "2", {"deep": "1-2"}],
+        }
+    }
+
+
+def test_double_dollar_escapes_literal() -> None:
+    result = _interpolate_env_vars(
+        {"price": "$$5.00", "mixed": "$${KEEP} ${REPLACE}"},
+        environ={"REPLACE": "yes"},
+    )
+    assert result == {"price": "$5.00", "mixed": "${KEEP} yes"}
+
+
+def test_non_string_scalars_pass_through() -> None:
+    data = {"num": 42, "flag": True, "none": None, "float": 1.5}
+    assert _interpolate_env_vars(data, environ={}) == data
+
+
+def test_strings_without_substitutions_pass_through() -> None:
+    data = {"a": "no vars here", "b": "neither $here without braces"}
+    assert _interpolate_env_vars(data, environ={}) == data
+
+
+def test_lowercase_placeholders_passed_through_for_cel_template() -> None:
+    """Lowercase ``${name}`` is reserved for the CEL ``template()`` function
+    and must not be touched by env-var interpolation, even when the env is
+    empty."""
+    data = {"prompt": "hello ${available_skills} from ${user_context}"}
+    assert _interpolate_env_vars(data, environ={}) == data
+
+
+def test_mixed_uppercase_and_lowercase() -> None:
+    """Uppercase names are interpolated; lowercase pass through untouched."""
+    result = _interpolate_env_vars(
+        {"text": "${HOST} -- ${user_name}"},
+        environ={"HOST": "example.com"},
+    )
+    assert result == {"text": "example.com -- ${user_name}"}
+
+
+def test_load_declarative_config_substitutes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_MODEL", "gpt-4o-mini")
+    yaml_content = """\
+manifest_version: 1
+
+llms:
+  - id: gpt
+    version: "1.0.0"
+    model_name: ${MY_MODEL}
+
+prompts:
+  - id: sys
+    version: "1.0.0"
+    instructions: "Be helpful"
+
+agents:
+  my-agent:
+    state:
+      fields:
+        - name: messages
+          type: list
+          default: []
+    graph:
+      entry_point: start
+      nodes:
+        - name: start
+          type: set_state
+          args:
+            values:
+              x: '"hello"'
+      edges: []
+"""
+    config = load_declarative_config(yaml_content=yaml_content)
+    assert config.llms[0].model_name == "gpt-4o-mini"
+
+
+def test_load_declarative_config_missing_var_raises() -> None:
+    yaml_content = """\
+manifest_version: 1
+
+llms:
+  - id: gpt
+    version: "1.0.0"
+    model_name: ${UNSET_MODEL}
+
+prompts:
+  - id: sys
+    version: "1.0.0"
+    instructions: "Be helpful"
+
+agents:
+  a:
+    state: { fields: [{name: messages, type: list, default: []}] }
+    graph:
+      entry_point: s
+      nodes:
+        - name: s
+          type: set_state
+          args: { values: { x: '"hi"' } }
+      edges: []
+"""
+    with pytest.raises(DeclarativeConfigError, match="UNSET_MODEL"):
+        load_declarative_config(yaml_content=yaml_content)

--- a/tests/langgraph/declarative/test_mcp_servers.py
+++ b/tests/langgraph/declarative/test_mcp_servers.py
@@ -1,0 +1,176 @@
+"""Tests for first-class ``mcp_servers:`` support in declarative YAML."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import ValidationError
+
+from sherma.entities.base import DEFAULT_TENANT_ID
+from sherma.langgraph.declarative.loader import (
+    _build_mcp_connection,
+    populate_registries,
+)
+from sherma.langgraph.declarative.schema import DeclarativeConfig, MCPServerDef
+from sherma.registry.bundle import RegistryBundle
+
+
+def _fake_tool(name: str) -> StructuredTool:
+    def _fn(**_: object) -> str:
+        return ""
+
+    return StructuredTool.from_function(
+        func=_fn,
+        name=name,
+        description=f"fake mcp tool {name}",
+    )
+
+
+def test_http_server_requires_url() -> None:
+    with pytest.raises(ValidationError, match="requires 'url'"):
+        MCPServerDef(id="srv", transport="streamable_http")
+
+
+def test_stdio_server_requires_command() -> None:
+    with pytest.raises(ValidationError, match="requires 'command'"):
+        MCPServerDef(id="srv", transport="stdio")
+
+
+def test_http_server_rejects_command() -> None:
+    with pytest.raises(ValidationError, match="must not set 'command'"):
+        MCPServerDef(
+            id="srv",
+            transport="streamable_http",
+            url="https://example.com",
+            command="should-not-be-here",
+        )
+
+
+def test_stdio_server_rejects_url() -> None:
+    with pytest.raises(ValidationError, match="must not set 'url'"):
+        MCPServerDef(
+            id="srv",
+            transport="stdio",
+            command="uvx",
+            url="https://example.com",
+        )
+
+
+def test_build_connection_streamable_http() -> None:
+    server = MCPServerDef(
+        id="factset",
+        transport="streamable_http",
+        url="https://factset.example.com/mcp",
+        headers={"Authorization": "Bearer abc"},
+    )
+    conn = _build_mcp_connection(server)
+    assert conn == {
+        "transport": "streamable_http",
+        "url": "https://factset.example.com/mcp",
+        "headers": {"Authorization": "Bearer abc"},
+    }
+
+
+def test_build_connection_stdio() -> None:
+    server = MCPServerDef(
+        id="local",
+        transport="stdio",
+        command="uvx",
+        args=["my-mcp-server"],
+        env={"DEBUG": "1"},
+    )
+    conn = _build_mcp_connection(server)
+    assert conn == {
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["my-mcp-server"],
+        "env": {"DEBUG": "1"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_populate_registries_registers_mcp_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_connections: dict[str, dict[str, object]] = {}
+
+    class FakeMultiServerMCPClient:
+        def __init__(self, connections: dict[str, dict[str, object]]) -> None:
+            captured_connections.update(connections)
+
+        async def get_tools(
+            self, *, server_name: str | None = None
+        ) -> list[StructuredTool]:
+            assert server_name == "factset"
+            return [_fake_tool("fundamentals_query"), _fake_tool("estimates_lookup")]
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.MultiServerMCPClient",
+        FakeMultiServerMCPClient,
+    )
+
+    config = DeclarativeConfig(
+        manifest_version=1,
+        mcp_servers=[
+            MCPServerDef(
+                id="factset",
+                version="1.0.0",
+                transport="streamable_http",
+                url="https://factset.example.com/mcp",
+            )
+        ],
+    )
+    registries = RegistryBundle(tenant_id=DEFAULT_TENANT_ID)
+
+    await populate_registries(config, registries)
+
+    assert captured_connections["factset"]["url"] == "https://factset.example.com/mcp"
+
+    fundamentals = await registries.tool_registry.get("fundamentals_query", "==1.0.0")
+    estimates = await registries.tool_registry.get("estimates_lookup", "==1.0.0")
+    assert fundamentals.id == "fundamentals_query"
+    assert estimates.id == "estimates_lookup"
+
+
+@pytest.mark.asyncio
+async def test_populate_registries_applies_tool_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeMultiServerMCPClient:
+        def __init__(self, _: dict[str, object]) -> None: ...
+
+        async def get_tools(
+            self, *, server_name: str | None = None
+        ) -> list[StructuredTool]:
+            return [_fake_tool("query")]
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.MultiServerMCPClient",
+        FakeMultiServerMCPClient,
+    )
+
+    config = DeclarativeConfig(
+        manifest_version=1,
+        mcp_servers=[
+            MCPServerDef(
+                id="factset",
+                version="1.0.0",
+                transport="streamable_http",
+                url="https://example.com/mcp",
+                tool_prefix="factset__",
+            )
+        ],
+    )
+    registries = RegistryBundle(tenant_id=DEFAULT_TENANT_ID)
+
+    await populate_registries(config, registries)
+
+    prefixed = await registries.tool_registry.get("factset__query", "==1.0.0")
+    assert prefixed.id == "factset__query"
+
+
+@pytest.mark.asyncio
+async def test_no_mcp_servers_is_noop() -> None:
+    config = DeclarativeConfig(manifest_version=1)
+    registries = RegistryBundle(tenant_id=DEFAULT_TENANT_ID)
+    await populate_registries(config, registries)


### PR DESCRIPTION
## Summary

Closes two of the visible gaps surfaced in #74 when comparing sherma's `agent.yaml` to Claude Managed Agents':

- **First-class MCP support**: a top-level `mcp_servers:` block declares MCP servers (HTTP / SSE / stdio). On config load, each server's tools are listed via `langchain_mcp_adapters.client.MultiServerMCPClient` and registered in the tool registry — so they pick up automatically via the existing `tools:` and `use_tools_from_registry: true` binding modes on `call_llm`. An optional `tool_prefix` namespaces registered tool ids when multiple servers expose colliding names.
- **`${VAR}` env-var interpolation in YAML**: every string value is run through `${VAR}` / `${VAR:-default}` substitution, with `$$` as the literal-`$` escape. Restricted to `UPPERCASE_WITH_UNDERSCORES` names so existing CEL `template()` placeholders (which use lowercase, e.g. `${available_skills}`) pass through untouched.

```yaml
mcp_servers:
  - id: factset
    transport: streamable_http
    url: ${FACTSET_MCP_URL}
    headers: { Authorization: "Bearer ${FACTSET_TOKEN}" }
    tool_prefix: "factset__"
  - id: filesystem
    transport: stdio
    command: uvx
    args: ["mcp-server-filesystem"]

llms:
  - id: openai
    provider: openai
    model_name: ${OPENAI_MODEL:-gpt-4o-mini}
```

Both features are additive: existing YAMLs without `mcp_servers:` or `${VAR}` substitutions continue to work unchanged.

### Files changed
- `sherma/langgraph/declarative/schema.py` — new `MCPServerDef`; `mcp_servers: list[MCPServerDef]` on `DeclarativeConfig`.
- `sherma/langgraph/declarative/loader.py` — `_interpolate_env_vars` (recursive, `${VAR}` / `${VAR:-default}` / `$$`); `_register_mcp_servers` (connects, lists, registers).
- `tests/langgraph/declarative/test_env_interpolation.py` — 12 new tests.
- `tests/langgraph/declarative/test_mcp_servers.py` — 9 new tests using a fake `MultiServerMCPClient`.
- `docs/declarative-agents.md`, `docs/api-reference.md` — new "Environment-variable interpolation" and "MCP Servers" sections.
- `skills/sherma/SKILL.md` and mirrored `skills/sherma/references/*.md` — quick-reference updates.
- `tasks/74-mcp-and-env-var-interpolation.md`, `tasks/plans/74-mcp-and-env-var-interpolation.md` — task and plan per `CLAUDE.md`.

## Test plan
- [x] `uv run ruff check .` (passes)
- [x] `uv run ruff format --check .` (passes)
- [x] `uv run pytest -m "not integration"` — 626 passed, 7 skipped (was 605, +21 new tests)
- [x] `uv run pytest tests/integration/test_declarative_skill_agent.py` — passes (verified lowercase `${available_skills}` placeholder still works after the uppercase-only restriction)
- [x] `uv run pyright` — no new errors (73 pre-existing streamlit/fastapi errors unchanged)

Closes #74 (partially — see issue comment for the wider comparison).

https://claude.ai/code/session_011kbKzXRst8h2NqiudssdjY

---
_Generated by [Claude Code](https://claude.ai/code/session_011kbKzXRst8h2NqiudssdjY)_